### PR TITLE
Unignore generated images.

### DIFF
--- a/.github/workflows/render-site.yaml
+++ b/.github/workflows/render-site.yaml
@@ -57,8 +57,8 @@ jobs:
     - run: mdbook build
     - name: Rendered manifest
       run: find ./docs -type f -exec ls -ld '{}' \;
-    - name: Unignore docs
-      run: sed -i 's|^docs/$||' .gitignore ; cat .gitignore
+    - name: Unignore docs and generated images
+      run: sed -i 's|^docs/$||; s|^\*\.generated\.svg$||' .gitignore ; cat .gitignore
     - name: Disable jekyll
       run: touch .nojekyll
     - name: Commit and Push render to gh-pages


### PR DESCRIPTION
There was a bug in the render action that left the `.gitignore` for generated images, so they didn't appear on the public gh pages site.